### PR TITLE
Fix #9

### DIFF
--- a/SuperTasks/views.py
+++ b/SuperTasks/views.py
@@ -8,4 +8,4 @@ from django.contrib.auth.decorators import login_required
 def index(request):
     context = {}  # reserved for later use in rendering home
 
-    return render(request, 'accounts/login.html', context)
+    return render(request, 'index.html', context)

--- a/SuperTasks/views.py
+++ b/SuperTasks/views.py
@@ -2,13 +2,10 @@
 
 from django.shortcuts import render
 from django.http import HttpResponse
+from django.contrib.auth.decorators import login_required
 
-
+@login_required
 def index(request):
     context = {}  # reserved for later use in rendering home
 
-    # Checks session cookie if they are logged in or not
-    if 'username' in request.session:
-        context['username'] = request.session['username']
-    
     return render(request, 'accounts/login.html', context)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,6 +6,6 @@ from . import views # SuperTasks custom views
 urlpatterns = [
     path("test/", views.test_view, name="test"),
     path("register/", views.register_view, name="register"),
-    path('login/', auth_views.LoginView.as_view(template_name='accounts/login.html'), name='login'),
+    path('login/', auth_views.LoginView.as_view(template_name='accounts/login.html', redirect_authenticated_user=True), name='login'),
     path('logout/', auth_views.LogoutView.as_view(next_page='login'), name='logout'),
 ]


### PR DESCRIPTION
- Require being logged in to see the `/` URL
- Require not being logged in to see the `/accounts/login` URL
- Render the "index.html" on the `/` URL rather than the "login.html"