### PR TITLE
Add configuration files for GCloud deployment

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,23 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Python pycache:
+__pycache__/
+
+# Local Database files
+db.sqlite3
+
+# Cloud SQL Proxy
+cloud_sql_proxy

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ GitHub.sublime-settings
 !.vscode/launch.json 
 !.vscode/extensions.json 
 .history
+
+# Google Cloud SQL Proxy
+cloud_sql_proxy

--- a/SuperTasks/settings.py
+++ b/SuperTasks/settings.py
@@ -25,7 +25,12 @@ SECRET_KEY = 'xv9uwn3qkkw73h(_wi-3%fpz^83o$)6odi4!g7*god#@7gogf#'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    'localhost',
+    '127.0.0.1',
+    'osu-cs361-supertasks.uc.r.appspot.com',
+    'osu-cs361-supertasks.appspot.com',
+]
 
 
 # Application definition
@@ -74,16 +79,52 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'SuperTasks.wsgi.application'
 
-
-# Database
-# https://docs.djangoproject.com/en/3.0/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+if os.getenv('GAE_APPLICATION', None):
+    # Running on production App Engine, so connect to Google Cloud SQL using
+    # the unix socket at /cloudsql/<your-cloudsql-connection string>
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'HOST': '/cloudsql/osu-cs361-supertasks:us-central1:osu-cs361-supertasks',
+            'USER': 'django',
+            'PASSWORD': 'django',
+            'NAME': 'supertasks',
+        }
     }
-}
+else:
+    # Running locally so connect to either a local MySQL instance or connect to
+    # Cloud SQL via the proxy. To start the proxy via command line:
+    #
+    #     $ cloud_sql_proxy -instances=[INSTANCE_CONNECTION_NAME]=tcp:3306
+    #
+    # INSTANCE_CONNECTION_NAME = osu-cs361-supertasks:us-central1:osu-cs361-supertasks
+    # See https://cloud.google.com/sql/docs/mysql-connect-proxy
+    #
+    # If we want to run MySQL locally through the gcloud proxy
+    # uncomment below and comment the SQLite setting.
+    #
+    #DATABASES = {
+    #    'default': {
+    #        'ENGINE': 'django.db.backends.mysql',
+    #        'HOST': '127.0.0.1',
+    #        'PORT': '3306',
+    #        'NAME': 'supertasks',
+    #        'USER': 'django',
+    #        'PASSWORD': 'django',
+    #    }
+    #}
+    #
+    # Database
+    # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
+    #
+    # Otherwise we can use the built-in SQLite database locally
+
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        }
+    }
 
 
 # Password validation

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,15 @@
+# [START django_app]
+runtime: python37
+
+handlers:
+# This configures Google App Engine to serve the files in the app's static
+# directory.
+- url: /static
+  static_dir: static/
+
+# This handler routes all requests not caught above to your main app. It is
+# required when static routes are defined, but can be omitted (along with
+# the entire handlers section) when there are no static files defined.
+- url: /.*
+  script: auto
+# [END django_app]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,10 @@
+from SuperTasks.wsgi import application
+
+# App Engine by default looks for a main.py file at the root of the app
+# directory with a WSGI-compatible object called app.
+# This file imports the WSGI-compatible object of your Django app,
+# application from mysite/wsgi.py and renames it app so it is discoverable by
+# App Engine without additional configuration.
+# Alternatively, you can add a custom entrypoint field in your app.yaml:
+# entrypoint: gunicorn -b :$PORT mysite.wsgi
+app = application

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Django==3.0.5
+django-widget-tweaks==1.4.8
+mysqlclient==1.4.6


### PR DESCRIPTION
The following files are necessary for GCloud deployment

- app.yaml : Describes the runtime GCloud should use
- requirements.txt : Describes the python modules GCloud should download
- .gcloudignore : Stops certain files from being uploaded to GCloud
- main.py : Main entry point to the app, GCloud runs 'python
main.py'
- settings.py : Update database information to connect to MySQL database
inside GCloud but keep using SQLite when testing locally. Also update
allowed host names