### PR TITLE
local-requirements.txt

### DIFF
--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -1,4 +1,3 @@
 Django==3.0.5
 django-widget-tweaks==1.4.8
 Pillow==7.1.2
-mysqlclient==1.4.6


### PR DESCRIPTION
local-requirements.txt file for use in development environments using django built-in SQLite vice the production environment mySQL.  Use python -m pip install -r local-requirements.txt to install dependencies on the local development environment.

basically removed mysqlclient as a dependency to prevent crashing during dependency install.