### PR TITLE
Add setting to run Cloud SQL Proxy locally

### DIFF
--- a/SuperTasks/settings.py
+++ b/SuperTasks/settings.py
@@ -80,7 +80,7 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'SuperTasks.wsgi.application'
 
-if os.getenv('GAE_APPLICATION', None):
+if os.getenv('GAE_APPLICATION', None) and DEBUG is False:
     # Running on production App Engine, so connect to Google Cloud SQL using
     # the unix socket at /cloudsql/<your-cloudsql-connection string>
     DATABASES = {
@@ -92,7 +92,7 @@ if os.getenv('GAE_APPLICATION', None):
             'NAME': 'supertasks',
         }
     }
-else:
+elif DEBUG is False:
     # Running locally so connect to either a local MySQL instance or connect to
     # Cloud SQL via the proxy. To start the proxy via command line:
     #
@@ -104,16 +104,18 @@ else:
     # If we want to run MySQL locally through the gcloud proxy
     # uncomment below and comment the SQLite setting.
     #
-    #DATABASES = {
-    #    'default': {
-    #        'ENGINE': 'django.db.backends.mysql',
-    #        'HOST': '127.0.0.1',
-    #        'PORT': '3306',
-    #        'NAME': 'supertasks',
-    #        'USER': 'django',
-    #        'PASSWORD': 'django',
-    #    }
-    #}
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'HOST': '127.0.0.1',
+            'PORT': '3306',
+            'NAME': 'supertasks',
+            'USER': 'django',
+            'PASSWORD': 'django',
+        }
+    }
+else:
+
     #
     # Database
     # https://docs.djangoproject.com/en/3.0/ref/settings/#databases


### PR DESCRIPTION
To use SQLite database locally, keep the settings as is.

To use the Cloud SQL Proxy which is a local MySQL database that connects
to the Google Cloud MySQL database, set DEBUG=False and follow the
directions in the comments.

Before deploying the code to Google Cloud, set DEBUG=False and the rest
should take care of itself