### PR TITLE
Add Github Action workflow deploy to GAE

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -1,0 +1,39 @@
+name: Deploy Workflow
+# This workflow is triggered on pushes to the master branch.
+on:
+  push:
+    branches:  
+    - master
+
+jobs:
+  deploy:
+    name: Deploy
+
+    # Python should run the same on all OS but choosing Linux since that's what servers run on.
+    runs-on: ubuntu-latest
+
+    steps:
+    # Check out code
+    - uses: actions/checkout@v2
+    # Set up Python
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+    # Download project dependencies
+    - name: Install Python Packages
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    # Run Django tests
+    - name: Run Tests
+      run: |
+        python manage.py test
+    # Deploy to Google App Engine
+    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      with:
+        version: '290.0.1'
+        project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
+        service_account_key: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+        export_default_credentials: true
+    - run: gcloud app deploy

--- a/SuperTasks/settings.py
+++ b/SuperTasks/settings.py
@@ -80,7 +80,8 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'SuperTasks.wsgi.application'
 
-if os.getenv('GAE_APPLICATION', None) and DEBUG is False:
+if os.getenv('GAE_APPLICATION', None):
+    DEBUG = False
     # Running on production App Engine, so connect to Google Cloud SQL using
     # the unix socket at /cloudsql/<your-cloudsql-connection string>
     DATABASES = {


### PR DESCRIPTION
Adds a workflow in Github Actions to deploy the application to Google
App Engine when a branch is merged into master and the Django tests pass. Requires secrets to be set in Github (credentials sent privately to Craig)