### PR TITLE
Adds database migrations in deploy script

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -25,10 +25,16 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    # Update migrations
+    - name: Database migrations
+      run: |
+        python manage.py makemigrations
+        python manage.py migrate
     # Run Django tests
     - name: Run Tests
       run: |
         python manage.py test
+        
     # Deploy to Google App Engine
     - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       with:


### PR DESCRIPTION
The test portion of the deploy script was failing because it wasn't creating the databases using `python manage.py makemigrations` and `python manage.py migrate`