### PR TITLE
Add instructions for migrating database changes

### DIFF
--- a/DATABASE_MIGRATION_README.md
+++ b/DATABASE_MIGRATION_README.md
@@ -1,0 +1,43 @@
+# Django Database Migration in Google Cloud SQL
+
+## Local Migrations
+When changes are made to models, we can update our databases locally by running:
+
+```
+# While using our virtual environment
+python manage.py makemigrations
+python manage.py migrate
+```
+
+This will update the SQL tables in our local file `db.sqlite3`. If your database ever gets seriously screwed up, you can delete that file and start over, however using the migration process that should never happen.
+
+It's advised to have a local startup script that activates the virtual environment, pulls the latest from Github, and runs the migration commands above before running the server for local development.
+
+## Migrations on Google Cloud SQL
+
+We can run the same migration commands, but we have to proxy our local SQL connection to connect to the instance inside of Google Cloud.
+
+Start by reading the information on the [MySQL connect proxy documentation](https://cloud.google.com/sql/docs/mysql-connect-proxy) page.
+In particular, follow the steps to "Install the proxy". This will download a `cloud_sql_proxy` binary file that you can execute from the command line.
+
+To open a connection to the Cloud SQL database, run the following command from the root directory of the project (the same directory as this README).
+
+```
+./cloud_sql_proxy -instances=osu-cs361-supertasks:us-central1:osu-cs361-supertasks=tcp:3306 -credential_file=osu-cs361-supertasks-82eaf62fc7cb.json
+
+```
+Note the credentials JSON file contains the credentials of a service user in Google Cloud that is allowed to access our SQL databse.
+
+Some messages will appear in your terminal but a successful connection should say "Ready for new connections".
+
+Next, in the SuperTasks/settings.py set the variable `USE_CLOUD_SQL_PROXY` to `True`. Make sure to not commit this change and to set it back after you are done.
+
+Finally, run the migration commands from a different terminal window.
+
+```
+# While using our virtual environment
+python manage.py makemigrations
+python manage.py migrate
+```
+
+From the `settings.py` configuration, Django will connect to a SQL database on local port 3306 with proper credentials. Local port 3306 is actually proxying to the Google Cloud SQL database instance because of the `cloud_sql_proxy` program that is running.

--- a/SuperTasks/settings.py
+++ b/SuperTasks/settings.py
@@ -81,6 +81,10 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'SuperTasks.wsgi.application'
 
+# Set this to True when running migrations on the Google Cloud SQL database
+# See DATABASE_MIGRATION_README.md for more information.
+USE_CLOUD_SQL_PROXY = False
+
 if os.getenv('GAE_APPLICATION', None):
     DEBUG = False
     # Running on production App Engine, so connect to Google Cloud SQL using
@@ -94,17 +98,9 @@ if os.getenv('GAE_APPLICATION', None):
             'NAME': 'supertasks',
         }
     }
-elif DEBUG is False:
-    # Running locally so connect to either a local MySQL instance or connect to
-    # Cloud SQL via the proxy. To start the proxy via command line:
-    #
-    #     $ cloud_sql_proxy -instances=[INSTANCE_CONNECTION_NAME]=tcp:3306
-    #
-    # INSTANCE_CONNECTION_NAME = osu-cs361-supertasks:us-central1:osu-cs361-supertasks
-    # See https://cloud.google.com/sql/docs/mysql-connect-proxy
-    #
-    # If we want to run MySQL locally through the gcloud proxy
-    # uncomment below and comment the SQLite setting.
+elif USE_CLOUD_SQL_PROXY is True:
+    # Connect to Google Cloud SQL via the proxy.
+    # See DATABASE_MIGRATION_README.md for information on how to connect the proxy.
     #
     DATABASES = {
         'default': {
@@ -117,12 +113,8 @@ elif DEBUG is False:
         }
     }
 else:
-
-    #
-    # Database
+    # Built-in SQLite database for local development
     # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
-    #
-    # Otherwise we can use the built-in SQLite database locally
 
     DATABASES = {
         'default': {

--- a/osu-cs361-supertasks-82eaf62fc7cb.json
+++ b/osu-cs361-supertasks-82eaf62fc7cb.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "osu-cs361-supertasks",
+  "private_key_id": "82eaf62fc7cb679171b9de99a01a1d8565050046",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCt8Un7Spujaia8\nKBY4O/3TOj8bGNcrDGZAknpVNOrPAw0KVtIrvJ6Or9zduEOuaMnQteTPsvN+PN5b\nH4ocVIiMH/TGu/iCQIJQnTBRPATRqVOgI7rUqxSSlx39b1Rd203ggnelMZFw9yeh\nslj6m5b55RDz+yuPO3yH9SD5aeXpvchKJstOHL3I2w52IoLsFYRXlUFG1ncXnC7l\no/mDAVUjWdAT9QAa/EilBIYWgq3ax5+GwvtOLt4TF3E0Eek1sZJjJJhxC7TJW2oA\nb1g94HlKAnopq5Cc6FucUSYUC1olY7IJWL/VWKfV95KIasMG8CRxHKMNFDMLUJ7p\nGUzfXpSFAgMBAAECggEAA4spddD7nEZuY61fY/dBo8OsVM+r9/c6HGuoPnIM2xxV\nqi0Hz1y/lgGUjEYq9haag2TDbs0Rir+y+fiJvyuNKGmlV3Rns53LGGSzZ7OJLt6k\n0tAjKu/i8qJ8ImyUEKcRsTmee+vtL48boNAuSoOhw1tCcksZEAks4+RcgGJ3ae9I\nkGH2DU7NsyT40ucZrMaNdx1SSpgYZTfcJX6RaIWxVCzZL0CY8nd/u/kruBdKsjQy\nErks+XybtZOCXzhwT7NUVbQwLY6VuYyB3mHvZIS9k4a2OTRBhdtn853LMlvqKQi+\n45fDmd+tzgnoHY1rtSbC5T2/5ggCnu3P9yYxZK//6wKBgQDcVWNqnf3NZ0Lhu2yZ\n30IcwxXaWyhlz24rqXB2sMmcrBhTqDTEHpX/Ej81iV/mxHzWIHUurdt8jL+xq1Yq\ncX5IxUcKHjpiNcHp/rcoPeXmbJnEYLvTDT/00S53SKWZ09Y43gY5TWjjB8cRmRlV\numd5AmAeGGPo1SmzOGi/1og+KwKBgQDKGXWUDso/x9Q7AwvWwQJ95P/7ct7DUGkW\nBNEWl6XMsZSq2K8a4YOPHFzo6KnvSKLY4F5vIVe1t0O0KyyPoevmpVs602G4EaRd\n2rqph2IarfEIkDPelq/6JFXD5nj5UaYrmPXBa9heSXkZqgXkashWBTLrKSfqZ7Zf\nJtCtQKDQDwKBgDdCv0V9TKuYq4CcFlfdU+KM101FsbMfPF19CLTsEBTYYN2SgXFy\nzmID/JB73O6u9zRpPZqwhi0NzAJOm7TXdDniKLgT7sa0/uamON/B7ohFUqebL2B2\noUTQthu6v7X+GGt43AzBKn5OdBIo2N7UeqEyBFNoAJ7j36qQik0bDF6zAoGBAKYP\nSVeA15qUvcRHeoDZUwzTD6sy9euStOZMyuk/bhLFj5zaMvdpecorygPuuUNOcdC2\ne6HgycscbNsr5o+Wwtlf4ZhyfAbdKCueQGZwQaIebsFUi+pH8w0csgQn6hsiheGo\n67YkwUKoKIN3+yN2wmo8F1y3En8+/NEueaUCR6DtAoGBAIDQLMcZSp5rr6zX/LFl\nMegYlCfz5OG4nE5Z6Q4/1IrxfR7uiQeWltAw5A+7Sujv2D9D+5t5Oy6EWz7Roz3r\n5tNin7EUSt6fOjqbQ3fkY+K6/D7Q2Zs58J+KQBIJSyat8Vqp/Gg8/5XGuuazf4YZ\nbMeEyXN863/xcyYMIDKXLGiW\n-----END PRIVATE KEY-----\n",
+  "client_email": "cloud-sql-proxy@osu-cs361-supertasks.iam.gserviceaccount.com",
+  "client_id": "102848048724159247500",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/cloud-sql-proxy%40osu-cs361-supertasks.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
- Adds a README for using the Cloud SQL proxy to perform migrations on
our production SQL database
- Clarifies the settings.py for when we are using the proxy
- Adds credentials for a service account that is able to access the
Cloud SQL database