### PR TITLE
Link projects to teams

### DIFF
--- a/accounts/templates/accounts/home.html
+++ b/accounts/templates/accounts/home.html
@@ -74,9 +74,22 @@
     <div class="container projects">
         <div class="header">
             <h1>Projects</h1>
-            <a class="projects-button" href="{% url 'projects' %}">All Projects</a>
         </div>
-       
+        <div class="project-list">
+            {% if projects %}
+            {% for project in projects %}
+            <div class="project-preview">
+                <h3>{{project.name}} | {{project.project_team}}</h3>
+                <a href="{% url 'projects_detail' project.id %}"><i class="fas fa-users-cog"></i></a>
+            </div>
+            {% endfor%}
+            {% else %}
+            <div class="project-preview">
+                <h3>You have no active projects</h3>
+                <a href="{% url 'projects_new' %}"><i class="fas fa-plus-circle"></i></a>
+            </div>
+            {% endif %}
+        </div>
     </div>
 
 {% endblock %}

--- a/accounts/templates/accounts/home.html
+++ b/accounts/templates/accounts/home.html
@@ -54,7 +54,7 @@
                     {% for team in teams %}
                         <div class="team-preview">
                             <h3>{{team}}</h3>
-                            <a href="{% url 'team' team.id %}"><i class="fas fa-users-cog"></i></a>
+                            <a href="{% url 'team' team.id %}"><i class="fas fa-user-edit"></i></a>
                         </div>
                     {% endfor%}
                 {% else %}
@@ -79,7 +79,10 @@
             {% if projects %}
             {% for project in projects %}
             <div class="project-preview">
-                <h3>{{project.name}} | {{project.project_team}}</h3>
+                <div>
+                    <h4>Project: {{project.name}} |</h4>
+                    <h5>Team: {{project.project_team}}</h5>
+                </div>
                 <a href="{% url 'projects_detail' project.id %}"><i class="fas fa-users-cog"></i></a>
             </div>
             {% endfor%}

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
 
 from .forms import RegisterForm, AccountSettingsForm
+from projects.models import Project
 
 # Create your views here.
 
@@ -70,12 +71,12 @@ def account_home(request):
     user_teams = account.team_set.all()
 
     #get project the user is working on
-    user_projects = request.user.project_set.all()
-    print(user_projects)
+    user_projects = Project.objects.filter(project_team__in=user_teams)
 
     context = {
         "account": account,
         "teams": user_teams,
+        "projects": user_projects,
     }
     return render(request, "accounts/home.html", context)
 

--- a/projects/forms.py
+++ b/projects/forms.py
@@ -1,11 +1,27 @@
-from django.forms import modelform_factory
+from django.forms import modelform_factory, ModelForm
+from django import forms
 from .models import Project, Feature
+from teams.models import Team
 
-# Automatically creates a form from the model
-ProjectForm = modelform_factory(
-    Project,
-    fields=("name", "description", "start_date", "due_date", "budget"),
-)
+#Automatically creates a form from the model
+# ProjectForm = modelform_factory(
+#     Project,
+#     fields=("name", "description", "start_date", "due_date", "budget", "project_team"),
+# )
+
+class ProjectForm(ModelForm):
+    class Meta:
+        model = Project
+        fields = ("name", "description", "start_date", "due_date", "budget", "project_team")
+
+    # ModelForm constructor adds project_team choice based off of the user requesting the form
+    def __init__(self, user, *args, **kwargs):
+        super(ProjectForm, self).__init__(*args, **kwargs)
+        self.fields['project_team'] = forms.ModelChoiceField(
+            queryset=user.account.team_set.all()
+        )
+    
+
 
 FeatureForm = modelform_factory(
     Feature,

--- a/projects/models.py
+++ b/projects/models.py
@@ -2,6 +2,8 @@ from datetime import date
 from django.db import models
 from django.contrib.auth.models import User
 
+from teams.models import Team
+
 # Create your models here.
 class Project(models.Model):
     """Model describing a Project
@@ -45,7 +47,9 @@ class Project(models.Model):
     #    related_name='project_leader',
     #)
     
-    members = models.ManyToManyField(User)
+    #members = models.ManyToManyField(User)
+    # each project will be linked to a team
+    project_team = models.ForeignKey(Team, on_delete=models.CASCADE)
 
     def is_overdue(self):
         "Returns True if today is greater than the Due Date and the project is not completed."
@@ -105,4 +109,3 @@ class Feature(models.Model):
         blank=True,
         default=None
     )
-

--- a/projects/templates/projects/new_project.html
+++ b/projects/templates/projects/new_project.html
@@ -13,6 +13,9 @@
     <!-- Google Fonts: Roboto -->
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@500&family=Roboto:wght@500&display=swap" rel="stylesheet">
 
+    {% comment %} Bootstrap Select for multi-select elements {% endcomment %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.17/dist/css/bootstrap-select.min.css">
+
     <!-- Font awesome icons for user and password fields -->
     <script src="https://kit.fontawesome.com/88cc25f307.js" crossorigin="anonymous"></script>
 {% endblock %}
@@ -48,6 +51,17 @@
                     <i class="form-field-icon fas fa-money-bill-alt fa-lg"></i>
                     {{form.budget|add_class:"form-input-field"|attr:"placeholder:Budget"}}
                 </span>
+                {% if teams %}
+                <span class="form-input-container">
+                    <i class="form-field-icon fas fa-users fa-lg"></i>
+                    {{form.project_team|add_class:"form-input-field"|attr:"placeholder:Team"}}
+                </span>
+                {% else %}
+                <span class="form-input-container">
+                    <i class="form-field-icon fas fa-exclamation fa-lg"></i>
+                    <a href="{% url 'new_team' %}" class="form-input-field">You must create a team before you can add a project!</a>
+                </span>
+                {% endif %}
                 <span class="form-button-container">
                     <input class="form-button submit" type="submit" value="Create">
                 </span>
@@ -56,5 +70,11 @@
             {{ form.errors }}
             {{ error }}
         </div>
+
+{% endblock %}
+
+{% block javascript %}
+{% comment %} Bootstrap Select for multi-select elements {% endcomment %}
+<script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.17/dist/js/bootstrap-select.min.js"></script>
 
 {% endblock %}

--- a/projects/templates/projects/project_edit.html
+++ b/projects/templates/projects/project_edit.html
@@ -34,6 +34,11 @@
             <div class="form-container">
                 <table class="table table-bordered">
                     <tr>
+                        <td class="active"><b>Team</b></td>
+                        <td class="active">{{ project_data.project_team }}</td>
+                        <td class="info"><button>edit</button></td>
+                    </tr>
+                    <tr>
                         <td class="active"><b>Name</b></td>
                         <td class="active">{{ project_data.name }}</td>
                         <td class="info"><button>edit</button></td>

--- a/projects/templates/projects/projects.html
+++ b/projects/templates/projects/projects.html
@@ -34,7 +34,7 @@
                         <span class="badge badge-danger ml-2">Overdue</span>
                         {% endif %}
                     </p>
-                    <p class="text-muted"><strong>Team: </strong>(to be added)</p>
+                    <p class="text-muted"><strong>Team: </strong>{{project.project_team}}</p>
 
                 </div>
                 <div class="card-footer">

--- a/projects/tests.py
+++ b/projects/tests.py
@@ -4,13 +4,16 @@ from datetime import date, timedelta
 from django.contrib.auth.models import User
 
 from .models import Project, Feature
+from teams.models import Team
 
 # Create your tests here.
 class ProjectModelTests(TestCase):
 
     def setUp(self):
         self.test_user = User(username='test_user', password='test_user')
+        self.test_team = Team(name="test_team")
         self.test_user.save()
+        self.test_team.save()
 
     def test_not_overdue(self):
         """Verifies that the is_overdue check returns False
@@ -53,7 +56,7 @@ class ProjectModelTests(TestCase):
         "Verifies that setting a Project to done will set all of its Features to done."
         tomorrow = date.today() + timedelta(days=1)
         # Create a Project objects
-        project = Project(name='test', description='test', due_date=tomorrow)
+        project = Project(name='test', description='test', due_date=tomorrow, project_team=self.test_team)
         project.save()
 
         # Create two Feature objects

--- a/projects/views.py
+++ b/projects/views.py
@@ -5,6 +5,7 @@ from django.db import Error
 from django.views.generic import CreateView
 
 from .models import Project, Feature
+from teams.models import Team
 from .forms import ProjectForm, FeatureForm
 
 # Create your views here.
@@ -78,10 +79,14 @@ def new_feature_view(request, project_id):
 
 @login_required
 def project_view(request):
-    data_p = Project.objects.all()
+    #get teams the user is a member of
+    user_teams = request.user.account.team_set.all()
+
+    #get project the user is working on
+    user_projects = Project.objects.filter(project_team__in=user_teams)
 
     context = {
-        "project_data": data_p,
+        "project_data": user_projects,
     }
     return render(request, "projects/projects.html", context)
 
@@ -106,27 +111,43 @@ def detail_project_view(request, project_id):
 @login_required
 def new_project_view(request):
     if request.method == 'GET':
-        context = {'form': ProjectForm()}
+        form = ProjectForm(request.user) #create form
+        teams = request.user.account.team_set.all() # query all teams user is on
+
+        context = {
+            'form': form,
+            "teams": teams,
+        }
         return render(request, 'projects/new_project.html', context)
 
     if request.method == 'POST':
-        form = ProjectForm(request.POST)
-
+        form = ProjectForm(request.user, request.POST)
+        
         if not form.is_valid():
-            context = {'form':form}
+            print(form.errors)
+            form = ProjectForm(request.user)  # create form
+            teams = request.user.account.team_set.all()  # query all teams user is on
+
+            context = {
+                'form': form,
+                "teams": teams,
+            }
             # put the error message in here
-            return render(request, 'accounts/new_project.html', context)
+            return render(request, 'projects/new_project.html', context)
 
         name = request.POST['name']
         description = request.POST['description']
         start_date = request.POST['start_date']
         due_date = request.POST['due_date']
         budget = request.POST['budget']
+        team_id = request.POST["project_team"]
+        project_team = Team.objects.get(id=team_id)
 
         try:
             Project.objects.create(name=name, description=description,
                                    start_date=start_date, due_date=due_date, 
-                                   budget=budget)
+                                   budget=budget, project_team=project_team)
+
             # Check where this redirects
             return HttpResponseRedirect('/projects')
         except Error as err:

--- a/static/CSS/account_home.css
+++ b/static/CSS/account_home.css
@@ -71,18 +71,20 @@
     width: 70%;
     padding: 15px 0;
     text-align: center;
-    border-radius: 25px;
+    border-radius: 15px;
     border: none;
     text-decoration: none;
     color: white;
     background-color: #ff6363;
     box-shadow: 0 3px 3px rgba(0, 0, 0, 0.3);
+    transition: 0.3s;
 }
 
 .update-button:hover {
     text-decoration: none;
     color: white;
     box-shadow: 0 4px 5px rgba(0, 0, 0, 0.5);
+    transform: scale(1.2);
 }
 
 .teams-tasks {
@@ -114,14 +116,16 @@
     font-size: 1.5em;
 }
 
-.team-preview a:hover {
+.team-preview a:hover i {
     background-color: #ff6363;
     color: white;
-    font-size: 2em;
+    /* font-size: 2em; */
+    transform: scale(1.3);
 }
 
 .team-preview i {
     font-size: inherit;
+    transition: 0.3s;
 }
 
 .project-preview {
@@ -148,12 +152,18 @@
     font-size: 1.5em;
 }
 
-.project-preview a:hover {
+.project-preview a:hover i {
     background-color: #ff6363;
     color: white;
-    font-size: 2em;
+    /* font-size: 2em; */
+    transform: scale(1.5);
 }
 
 .project-preview i {
     font-size: inherit;
+    transition: 0.3s;
+}
+
+.project-preview div {
+    padding: 8px;
 }

--- a/static/CSS/account_home.css
+++ b/static/CSS/account_home.css
@@ -123,3 +123,37 @@
 .team-preview i {
     font-size: inherit;
 }
+
+.project-preview {
+    border: 3px solid #ff6363;
+    margin: 5px 10px;
+    border-radius: 10px;
+    display: grid;
+    grid-template-columns: 1fr auto;
+}
+
+.project-preview h3 {
+    margin: 5px 10px;
+}
+
+.project-preview a {
+    text-decoration: none;
+    background-color: #ff6363;
+    color: white;
+    height: 100%;
+    padding: 0 25px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5em;
+}
+
+.project-preview a:hover {
+    background-color: #ff6363;
+    color: white;
+    font-size: 2em;
+}
+
+.project-preview i {
+    font-size: inherit;
+}

--- a/teams/views.py
+++ b/teams/views.py
@@ -11,8 +11,10 @@ from .forms import TeamForm
 @login_required
 def dashboard_view(request):
     "Displays a list of the existing teams and their members. URL: /teams"
-    teams = Team.objects.all()
-    context = {'teams': teams}
+    #get teams the user is a member of
+    user_teams = request.user.account.team_set.all()
+
+    context = {'teams': user_teams}
     return render(request, "teams/dashboard.html", context)
 
 


### PR DESCRIPTION
Updated projects to be linked to a team via a ForeignKey relationship. Projects and teams pages now only display the projects and teams that the current user is a part of. updated the styling on the accounts homepage as well.

Note for David: When I initially set up the foreign key relationship between the projects and teams and ran the database migration I had a lot of errors because some projects already existed without a team assigned to them. I ended up having to delete my local database and all the existing migrations before starting from scratch again. Will we have to worry about this with the GCloud database?