### PR TITLE
Edit teams

### DIFF
--- a/teams/views.py
+++ b/teams/views.py
@@ -66,36 +66,53 @@ def team_view(request, team_id):
 
         # Get a list of the member ids for pre-selecting the dropdown multi-select
         member_ids = [str(account.id) for account in team.accounts.all()]
-
+        print(member_ids)
         context = {
             'form': TeamForm(instance=team),
             'accounts': accounts,
             'is_new_team': False,
             'member_ids': member_ids,
         }
-        print("test")
         return render(request, "teams/team.html", context)
 
-    #TODO this method is not standard REST, need converted to PUT.
-    #TODO logic adds but does not remove users from the team.
+    #TODO this method is not standard REST, needs converted to PUT at future time.
     if request.method == 'POST':
-        # Replace with logic to update the existing team
 
-        form = TeamForm(request.POST)
+        # form = TeamForm(request.POST)
+        # name = request.POST['name']
+        
 
-        name = request.POST['name']
-        accounts = request.POST.getlist('accounts')
-        print(accounts)
         try:
-            team = Team.objects.get(id=team_id)
-            # print(team)
 
-            for account_id in accounts:
+            # create "set" of accounts to be added or removed
+            edit_accounts = set(request.POST.getlist('accounts'))
+            print(edit_accounts)
+
+            # existing team and team accounts
+            team = Team.objects.get(id=team_id)
+          
+            # create "set" of original accounts that exist in current team
+            orig_accounts = set([str(account.id) for account in team.accounts.all()])
+            print(orig_accounts)
+
+            # add accounts is the set difference of edit and original accounts
+            add_accounts = edit_accounts - orig_accounts
+
+            # remove accounts is the set set difference of original and edit accounts
+            remove_accounts = orig_accounts - edit_accounts
+
+            # iterate through the union of the two sets for each account_id
+            for account_id in add_accounts:
 
                 team.accounts.add(account_id)
 
+            for account_id in remove_accounts:
+                
+                team.accounts.remove(account_id)
+
             return HttpResponseRedirect('/teams')
 
+        #TODO this error does not redirect to correct location for failure to update a team.
         except Error as err:
 
             context = {'error': str(err), 'form': form}

--- a/teams/views.py
+++ b/teams/views.py
@@ -79,7 +79,6 @@ def team_view(request, team_id):
     if request.method == 'POST':
 
         try:
-
             # create "set" of accounts to be added or removed
             edit_accounts = set(request.POST.getlist('accounts'))
 
@@ -106,11 +105,9 @@ def team_view(request, team_id):
 
             return HttpResponseRedirect('/teams')
 
-        #TODO this error does not redirect to correct location for failure to update a team.
-        except Error as err:
+        except Team.DoesNotExist:
 
-            context = {'error': str(err), 'form': form}
-            return render(request, 'teams/new_team.html', context)
+            return HttpResponseNotFound(f'404: Team {team_id} does not exist.')
 
     # Return HTTP 405 Method Not Allowed
     return HttpResponseNotAllowed(['POST', 'GET'])

--- a/teams/views.py
+++ b/teams/views.py
@@ -66,7 +66,7 @@ def team_view(request, team_id):
 
         # Get a list of the member ids for pre-selecting the dropdown multi-select
         member_ids = [str(account.id) for account in team.accounts.all()]
-        print(member_ids)
+        
         context = {
             'form': TeamForm(instance=team),
             'accounts': accounts,

--- a/teams/views.py
+++ b/teams/views.py
@@ -78,22 +78,16 @@ def team_view(request, team_id):
     #TODO this method is not standard REST, needs converted to PUT at future time.
     if request.method == 'POST':
 
-        # form = TeamForm(request.POST)
-        # name = request.POST['name']
-        
-
         try:
 
             # create "set" of accounts to be added or removed
             edit_accounts = set(request.POST.getlist('accounts'))
-            print(edit_accounts)
 
             # existing team and team accounts
             team = Team.objects.get(id=team_id)
           
             # create "set" of original accounts that exist in current team
             orig_accounts = set([str(account.id) for account in team.accounts.all()])
-            print(orig_accounts)
 
             # add accounts is the set difference of edit and original accounts
             add_accounts = edit_accounts - orig_accounts


### PR DESCRIPTION
Adds logic to edit team members using set difference.  Allow addition and removal.
Modified error handling for edit route to return a 404 error if team does not exist.
Cleaned up teams.views.py for commenting, extra white space, and erroneous debugging print lines.
Left a TODO to one day change route handling to standard REST 'PUT' vice 'POST' for edit route.
Did NOT add a delete route since PROJECTs have a one to one relationship with TEAMS.